### PR TITLE
Replace TypeScript type 'any'

### DIFF
--- a/src/commands/bridge.ts
+++ b/src/commands/bridge.ts
@@ -8,7 +8,9 @@ import ApplicationCommand from "../types/ApplicationCommand"
 import { client } from ".."
 
 export default new ApplicationCommand({
-	permissions: ["botowner"],
+	settings: {
+		ownerOnly: true
+	},
 	data: new SlashCommandBuilder()
 		.setName("bridge")
 		.setDescription("Create or manage bridges between channels")

--- a/src/commands/command.ts
+++ b/src/commands/command.ts
@@ -12,7 +12,9 @@ const {
 } = require("discord.js")
 
 export default new ApplicationCommand({
-	permissions: ["botowner"],
+	settings: {
+		ownerOnly: true
+	},
 	data: new SlashCommandBuilder()
 		.setName("command")
 		.setDescription("Configure my commands")

--- a/src/commands/command.ts
+++ b/src/commands/command.ts
@@ -1,4 +1,4 @@
-import { ChatInputCommandInteraction } from "discord.js"
+import { ChatInputCommandInteraction, SlashCommandSubcommandBuilder, SlashCommandSubcommandGroupBuilder } from "discord.js"
 import ApplicationCommand from "../types/ApplicationCommand"
 import database from "../utils/database"
 import embeds from "../utils/embeds"
@@ -8,7 +8,6 @@ import { stripIndent, stripIndents } from "common-tags"
 import { permissions } from "../config.json"
 const {
 	SlashCommandBuilder,
-	SlashCommandSubcommandBuilder,
 	EmbedBuilder,
 } = require("discord.js")
 
@@ -17,11 +16,11 @@ export default new ApplicationCommand({
 	data: new SlashCommandBuilder()
 		.setName("command")
 		.setDescription("Configure my commands")
-		.addSubcommandGroup((group) =>
+		.addSubcommandGroup((group: SlashCommandSubcommandGroupBuilder) =>
 			group
 				.setName("alias")
 				.setDescription("alias")
-				.addSubcommand((command) =>
+				.addSubcommand((command: SlashCommandSubcommandBuilder) =>
 					command
 						.setName("create")
 						.setDescription("create an alias")
@@ -61,7 +60,7 @@ export default new ApplicationCommand({
 								.setDescription("override description"),
 						),
 				)
-				.addSubcommand((command) =>
+				.addSubcommand((command: SlashCommandSubcommandBuilder) =>
 					command
 						.setName("remove")
 						.setDescription("remove an alias")
@@ -76,7 +75,7 @@ export default new ApplicationCommand({
 					command.setName("list").setDescription("list all aliases"),
 				),
 		)
-		.addSubcommandGroup((group) =>
+		.addSubcommandGroup((group: SlashCommandSubcommandGroupBuilder) =>
 			group
 				.setName("command")
 				.setDescription("command")
@@ -103,7 +102,7 @@ export default new ApplicationCommand({
 						),
 				),
 		)
-		.addSubcommand((command) =>
+		.addSubcommand((command: SlashCommandSubcommandBuilder) =>
 			command
 				.setName("run")
 				.setDescription("run a command")

--- a/src/commands/eval.ts
+++ b/src/commands/eval.ts
@@ -30,7 +30,9 @@ const clean = async (text: string) => {
 }
 
 export default new ApplicationCommand({
-	permissions: ["botowner"],
+	settings: {
+		ownerOnly: true
+	},
 	data: new SlashCommandBuilder()
 		.setName("eval")
 		.setDescription("eval")

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -10,7 +10,9 @@ import { client } from ".."
 import { stripIndents } from "common-tags"
 
 export default new ApplicationCommand({
-	permissions: ["botowner"],
+	settings: {
+		ownerOnly: true
+	},
 	data: new SlashCommandBuilder()
 		.setName("help")
 		.setDescription("Display help information"),

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -15,6 +15,7 @@ import embeds from "../utils/embeds"
 import axios from "axios"
 import { stripIndent, stripIndents } from "common-tags"
 import moment from "moment"
+import { InviteSchema, UsernameSchema } from "../types/Database"
 
 // function fetchPromise(toFetch) {
 // 	return new Promise((resolve, reject) => {
@@ -250,10 +251,10 @@ export default new ApplicationCommand({
 					})
 
 					if (interaction.guild.members.resolve(user)) {
-						const invitedLink = await database.get(
+						const invitedLink = await database.get<string>(
 							`.guilds.${member.guild.id}.users.${member.id}.invitedLink`,
 						)
-						const invites: object = await database.get(
+						const invites = await database.get<InviteSchema>(
 							`.guilds.${member.guild.id}.invites`,
 						)
 						const invite = invites[invitedLink]
@@ -293,7 +294,7 @@ export default new ApplicationCommand({
 					if (image) infoEmbed.setImage(`${image}?size=4096`)
 				}
 				if (interaction.options.getString("show") == "usernames") {
-					const usernames = await database.get(
+					const usernames = await database.get<UsernameSchema>(
 						`.users.${user.id}.usernames`,
 					)
 					let text = `\n`

--- a/src/commands/invite.ts
+++ b/src/commands/invite.ts
@@ -13,6 +13,7 @@ import {
 	TextChannel,
 } from "discord.js"
 import ApplicationCommand from "../types/ApplicationCommand"
+import { InviteSchema, UserSchema } from "../types/Database"
 import database from "../utils/database"
 import embeds from "../utils/embeds"
 import format from "../utils/format"
@@ -132,7 +133,7 @@ export default new ApplicationCommand({
 					ephemeral: true,
 					embeds: embeds.messageEmbed("listing invites..."),
 				})
-				const invitelist = await database.get(
+				const invitelist = await database.get<InviteSchema[]>(
 					`.guilds.${interaction.guild.id}.invites`,
 				)
 				// console.log(invitelist)
@@ -261,7 +262,7 @@ export default new ApplicationCommand({
 				}
 
 				// create actionrow with confirm, delete button
-				const row: any = new ActionRowBuilder()
+				const row = new ActionRowBuilder<ButtonBuilder>()
 					.addComponents(
 						new ButtonBuilder()
 							.setCustomId("invite-confirmdelete")
@@ -446,7 +447,9 @@ export default new ApplicationCommand({
 
 				const invitedusers = []
 
-				const dbusers = await database.get(`.guilds.${guild.id}.users`)
+				const dbusers = await database.get<UserSchema[]>(
+					`.guilds.${guild.id}.users`,
+				)
 				for (let u in dbusers) {
 					if (dbusers.hasOwnProperty(u)) {
 						if (dbusers[u].invitedLink == code) {

--- a/src/commands/issue.ts
+++ b/src/commands/issue.ts
@@ -21,7 +21,9 @@ import error from "./error"
 import { stripIndents } from "common-tags"
 
 export default new ApplicationCommand({
-	permissions: ["botowner"],
+	settings: {
+		ownerOnly: true
+	},
 	data: new SlashCommandBuilder()
 		.setName("issue")
 		.setDescription("Report an issue"),

--- a/src/commands/level.ts
+++ b/src/commands/level.ts
@@ -4,6 +4,7 @@ import {
 	SlashCommandBuilder,
 } from "discord.js"
 import ApplicationCommand from "../types/ApplicationCommand"
+import { UserSchema } from "../types/Database"
 import database from "../utils/database"
 import calc from "../utils/calc"
 import embeds from "../utils/embeds"
@@ -93,8 +94,8 @@ export default new ApplicationCommand({
 				await interaction.deferReply()
 
 				// some terrible way to sort by xp
-				const users = await database.get(
-					`.guilds.${interaction.guild.id}.users`,
+				const users = await database.get<UserSchema[]>(
+					`.guilds.${interaction.guild.id}.users`
 				)
 				const usersArray = []
 				const guildUsers = await guild.members.fetch()

--- a/src/commands/raid.ts
+++ b/src/commands/raid.ts
@@ -8,7 +8,9 @@ import embeds from "../utils/embeds"
 import format from "../utils/format"
 
 export default new ApplicationCommand({
-	permissions: ["botowner"],
+	settings: {
+		ownerOnly: true
+	},
 	data: new SlashCommandBuilder()
 		.setName("raid")
 		.setDescription("Configure anti-raid measures")

--- a/src/commands/refresh.ts
+++ b/src/commands/refresh.ts
@@ -5,7 +5,9 @@ import embeds from "../utils/embeds"
 import database from "../utils/database"
 
 export default new ApplicationCommand({
-	permissions: ["botowner"],
+	settings: {
+		ownerOnly: true
+	},
 	data: new SlashCommandBuilder()
 		.setName("refresh")
 		.setDescription("Reloads the bot and commands"),

--- a/src/commands/roles.ts
+++ b/src/commands/roles.ts
@@ -18,6 +18,7 @@ import {
 import embeds from "../utils/embeds"
 import database from "../utils/database"
 import ApplicationCommand from "../types/ApplicationCommand"
+import { RolesListSchema, RolesMenuSchema } from "../types/Database"
 import emoji from "../utils/emoji"
 var stringSimilarity = require("string-similarity")
 
@@ -980,7 +981,7 @@ export default new ApplicationCommand({
 					}
 					// /roles lists get
 					case "get": {
-						const rolelists: RoleList[] = await database.get(
+						const rolelists = await database.get<RoleList[]>(
 							`.guilds.${interaction.guild.id}.roles.lists`,
 						)
 						if (
@@ -1078,10 +1079,10 @@ export default new ApplicationCommand({
 			case "selectrolemenu": {
 				await interaction.deferUpdate()
 				const menuid = interaction.message.id
-				const roleMenu = await database.get(
+				const roleMenu = await database.get<RolesMenuSchema>(
 					`.guilds.${interaction.guild.id}.roles.menus.${menuid}`,
 				)
-				const roleList = await database.get(
+				const roleList = await database.get<RolesListSchema>(
 					`.guilds.${interaction.guild.id}.roles.lists.${roleMenu.list}`,
 				)
 				const user = await interaction.user.fetch()
@@ -1135,10 +1136,10 @@ export default new ApplicationCommand({
 			case "buttonrolemenu": {
 				const roleid = id[2]
 				const menuid = interaction.message.id
-				const roleMenu = await database.get(
+				const roleMenu = await database.get<RolesMenuSchema>(
 					`.guilds.${interaction.guild.id}.roles.menus.${menuid}`,
 				)
-				const roleList = await database.get(
+				const roleList = await database.get<RolesListSchema>(
 					`.guilds.${interaction.guild.id}.roles.lists.${roleMenu.list}`,
 				)
 				console.log(roleMenu)

--- a/src/commands/settings.ts
+++ b/src/commands/settings.ts
@@ -10,9 +10,11 @@ import {
 	PermissionsBitField,
 	Role,
 	RoleSelectMenuBuilder,
+	RoleSelectMenuInteraction,
 	SlashCommandBuilder,
 	Snowflake,
 	StringSelectMenuBuilder,
+	StringSelectMenuInteraction,
 	TextChannel,
 } from "discord.js"
 import ApplicationCommand from "../types/ApplicationCommand"
@@ -73,22 +75,19 @@ export default new ApplicationCommand({
 			case "set": {
 				const settingName = interaction.options.getString("setting")
 				console.log(settingName)
-				const option: Setting =
-					settingsList[
-						settingsList.findIndex((e) => e.value === settingName)
-					]
+				const option: Setting = settingsList[settingName]
 				console.log(JSON.stringify(option))
 				const oldvalue = await settings.get(
 					interaction.guild,
-					settingName,
+					settingName
 				)
-				let value = ""
+				let value: string | void = ""
 				switch (option.type) {
 					case "channel": {
 						let channel = await channelSelector(
 							interaction,
 							option.name,
-							oldvalue,
+							oldvalue as string
 						)
 						if (channel) {
 							console.log(channel.name)
@@ -103,7 +102,7 @@ export default new ApplicationCommand({
 						let role = await roleSelector(
 							interaction,
 							option.name,
-							oldvalue,
+							oldvalue as string
 						)
 						if (role) {
 							console.log(role.name)
@@ -117,7 +116,7 @@ export default new ApplicationCommand({
 						value = await toggleSelector(
 							interaction,
 							option.name,
-							oldvalue,
+							oldvalue as string
 						)
 						break
 					}
@@ -126,7 +125,7 @@ export default new ApplicationCommand({
 							interaction,
 							option.name,
 							option.options,
-							oldvalue,
+							oldvalue as string
 						)
 						break
 					}
@@ -363,7 +362,7 @@ async function roleSelector(
 				.setLabel("none")
 				.setStyle(ButtonStyle.Danger),
 		)
-		const filter = (i) => {
+		const filter = (i: RoleSelectMenuInteraction) => {
 			return i.user.id === interaction.user.id
 		}
 		await interaction
@@ -430,8 +429,8 @@ async function roleSelector(
 async function toggleSelector(
 	interaction: ChatInputCommandInteraction,
 	setting: string,
-	oldvalue: string,
-): Promise<any> {
+	oldvalue: string
+): Promise<string | void> {
 	return stringSelector(
 		interaction,
 		setting,
@@ -447,67 +446,53 @@ async function stringSelector(
 	interaction: ChatInputCommandInteraction,
 	setting: string,
 	options: SelectorOption[],
-	oldvalue: string,
-): Promise<any> {
+	oldvalue: string
+): Promise<string | void> {
 	const title = `Choose a value for __${setting}__...`
 
-	return new Promise(async (resolve, reject) => {
-		const row =
-			new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
-				new StringSelectMenuBuilder()
-					.setCustomId("select")
-					.setPlaceholder("Nothing selected")
-					.setOptions(
-						...options.map((e) => {
-							if (!e.label) {
-								e.label = e.value
-							}
-							return e as SelectorOptionLabel
-						}),
-					),
+	const row = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
+		new StringSelectMenuBuilder()
+			.setCustomId("select")
+			.setPlaceholder("Nothing selected")
+			.setOptions(
+				...options.map((e) => {
+					if (!e.label) {
+						e.label = e.value
+					}
+					return e as SelectorOptionLabel
+				})
 			)
-		const filter = (i) => {
-			return i.user.id === interaction.user.id
-		}
-		await interaction
-			.reply({
-				embeds: embeds.messageEmbed(
-					title,
-					`**Currently**: *${oldvalue}*`,
-				),
-				components: [row],
-				ephemeral: true,
-			})
-			.then((message) => {
-				message
-					.awaitMessageComponent({
-						filter,
-						componentType: ComponentType.StringSelect,
-						time: 60000,
-					})
-					.then(async (i) => {
-						let value = i.values[0]
-						console.log(value)
-						interaction.editReply({
-							embeds: embeds.successEmbed(
-								title,
-								`You selected ${value}`,
-							),
-							components: [],
-						})
-						resolve(value)
-					})
-					.catch((err) => {
-						interaction.editReply({
-							embeds: embeds.warningEmbed(
-								title,
-								`Nothing selected`,
-							),
-							components: [],
-						})
-						setTimeout(() => interaction.deleteReply(), 10000)
-						// reject(new Error("Nothing selected"))
-					})
-			})
+	)
+	const filter = (i: StringSelectMenuInteraction) => {
+		return i.user.id === interaction.user.id
+	}
+	const message = await interaction.reply({
+		embeds: embeds.messageEmbed(title, `**Currently**: *${oldvalue}*`),
+		components: [row],
+		ephemeral: true,
 	})
+
+	return message
+		.awaitMessageComponent({
+			filter,
+			componentType: ComponentType.StringSelect,
+			time: 60000,
+		})
+		.then(async (i) => {
+			let value = i.values[0]
+			console.log(value)
+			interaction.editReply({
+				embeds: embeds.successEmbed(title, `You selected ${value}`),
+				components: [],
+			})
+			return value
+		})
+		.catch((err) => {
+			interaction.editReply({
+				embeds: embeds.warningEmbed(title, `Nothing selected`),
+				components: [],
+			})
+			setTimeout(() => interaction.deleteReply(), 10000)
+			// reject(new Error("Nothing selected"))
+		})
 }

--- a/src/commands/settings.ts
+++ b/src/commands/settings.ts
@@ -75,7 +75,10 @@ export default new ApplicationCommand({
 			case "set": {
 				const settingName = interaction.options.getString("setting")
 				console.log(settingName)
-				const option: Setting = settingsList[settingName]
+				const option: Setting =
+					settingsList[
+						settingsList.findIndex((e) => e.value === settingName)
+					]
 				console.log(JSON.stringify(option))
 				const oldvalue = await settings.get(
 					interaction.guild,

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -14,7 +14,9 @@ import database from "../utils/database"
 import moment, { now } from "moment"
 
 export default new ApplicationCommand({
-	permissions: ["botowner"],
+	settings: {
+		ownerOnly: true,
+	},
 	data: new SlashCommandBuilder()
 		.setName("test")
 		.setDescription("description"),

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -73,7 +73,7 @@ export default new Event({
 
 			// Check if the command is for owners only and if interaction executor are the owners
 			if (
-				command.settings.ownerOnly &&
+				command.settings?.ownerOnly &&
 				interaction.user.id !== config.permissions.botowner
 			) {
 				return

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -71,25 +71,27 @@ export default new Event({
 			const permlist = command.permissions || []
 			//console.log(command.permissions)
 
+			// Check if the command is for owners only and if interaction executor are the owners
+			if (
+				command.settings.ownerOnly &&
+				interaction.user.id !== config.permissions.botowner
+			) {
+				return
+			}
+
 			// for every permission set in the command, check it
-			for (let i = 0; i < permlist.length; i++) {
-				if (permlist[i] == "botowner") {
-					if (interaction.user.id !== config.permissions.botowner) {
-						return
-					}
+			for (const permission of permlist) {
+				console.log(permission)
+
+				if (interaction.memberPermissions.has(permission)) {
+					console.log("yes")
+					acceptedPermissions.push(permission)
 				} else {
-					console.log(i)
-					if (
-						(interaction.member.permissions as any).has(permlist[i])
-					) {
-						console.log("yes")
-						acceptedPermissions.push(permlist[i])
-					} else {
-						console.log("no")
-						deniedPermissions.push(permlist[i])
-					}
+					console.log("no")
+					deniedPermissions.push(permission)
 				}
 			}
+
 			for (let i = 0; i < deniedPermissions.length; i++) {
 				// permissionsText += `\n🚫 ** ${new PermissionsBitField(deniedPermissions[i],).toArray()}**` // get text name for each permission
 			}

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -55,7 +55,7 @@ export default new Event({
 						.toString()
 						.slice(0, -3)}:t>`,
 				)
-				const currentXp = await database.get(
+				const currentXp = await database.get<number>(
 					`.guilds.${guild.id}.users.${message.interaction.user.id}.xp`,
 				)
 				const newXp = Math.floor(currentXp + 100)
@@ -103,7 +103,7 @@ export default new Event({
 		// 	return
 
 		// }
-		const currentXp = await database.get(
+		const currentXp = await database.get<number>(
 			`.guilds.${guild.id}.users.${user.id}.xp`,
 		)
 		// newXp is random between +5 and +15

--- a/src/events/messageReactionAdd.ts
+++ b/src/events/messageReactionAdd.ts
@@ -6,6 +6,7 @@ import {
 	Message,
 	MessageReaction,
 	ReactionManager,
+	Snowflake,
 	User,
 } from "discord.js"
 import Event from "../types/Event"
@@ -15,6 +16,7 @@ import messageCreate from "./messageCreate"
 import embeds from "../utils/embeds"
 import { type } from "os"
 import openai from "../utils/openai"
+import { StarboardMessageSchema } from "../types/Database"
 
 // Emitted whenever a reaction is added to a message
 export default new Event({
@@ -46,15 +48,13 @@ export default new Event({
 		// reaction.message.channel.send("")
 
 		if (reaction.emoji.name == "⭐") {
-			const starboardChannelId = await database.get(
-				`.guilds.${guild.id}.settings.starboard_channel`,
+			const starboardChannelId = await database.get<Snowflake>(
+				`.guilds.${guild.id}.settings.starboard_channel`
 			)
 			if (!starboardChannelId) return
-			const starboardChannel = (await guild.channels.fetch(
-				starboardChannelId,
-			)) as GuildTextBasedChannel
+			const starboardChannel = (await guild.channels.fetch(starboardChannelId)) as GuildTextBasedChannel
 
-			let previousStars: any[] =
+			let previousStars: StarboardMessageSchema[] =
 				(await database.get(`.guilds.${guild.id}.starboard`)) || []
 
 			// rename this when sane

--- a/src/events/messageReactionRemove.ts
+++ b/src/events/messageReactionRemove.ts
@@ -5,9 +5,10 @@ import {
 	Interaction,
 	Message,
 	MessageReaction,
-	ReactionManager,
+	Snowflake,
 	User,
 } from "discord.js"
+import { StarboardMessageSchema } from "../types/Database"
 import Event from "../types/Event"
 import { client } from "../index"
 import database from "../utils/database"
@@ -43,7 +44,7 @@ export default new Event({
 		// console.log(`${reaction.count} user(s) have given the same reaction to this message!`)
 
 		if (reaction.emoji.name == "⭐") {
-			const starboardChannelId = await database.get(
+			const starboardChannelId = await database.get<Snowflake>(
 				`.guilds.${guild.id}.settings.starboard_channel`,
 			)
 			if (!starboardChannelId) return
@@ -51,7 +52,7 @@ export default new Event({
 				starboardChannelId,
 			)) as GuildTextBasedChannel
 
-			let previousStars: any[] =
+			let previousStars: StarboardMessageSchema[] =
 				(await database.get(`.guilds.${guild.id}.starboard`)) || []
 
 			// rename this when sane

--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -15,6 +15,7 @@ import invites from "../utils/invites"
 import embeds from "../utils/embeds"
 import axios from "axios"
 import { botlogchannel } from "../config.json"
+import { LastChannelSchema } from "../types/Database"
 
 export default new Event({
 	name: Events.ClientReady,
@@ -43,7 +44,9 @@ export default new Event({
 				invites.updateAllInviteCaches()
 
 				// say that the bots been restarted if /refresh was used
-				const restartinfo = await database.get(`.botdata.lastchannel`)
+				const restartinfo = await database.get<LastChannelSchema>(
+					`.botdata.lastchannel`
+				)
 				console.log(restartinfo)
 				if (restartinfo && restartinfo.message != null) {
 					const guild = await client.guilds.fetch(restartinfo.guild)

--- a/src/structures/BridgeManager.ts
+++ b/src/structures/BridgeManager.ts
@@ -10,6 +10,7 @@ import ChannelBridge from "./ChannelBridge"
 import { client } from ".."
 import format from "../utils/format"
 import webhooks from "../utils/webhooks"
+import { BridgeSchema } from "../types/Database"
 
 class BridgeManager {
 	bridges: ChannelBridge[]
@@ -77,7 +78,8 @@ class BridgeManager {
 
 	async initialise() {
 		await database.connect() // there's most likely a better way to do this or place to put this
-		const bridges = await database.get(".channelbridges")
+		const bridges = await database.get<BridgeSchema[]>(".channelbridges")
+		if (!bridges?.length) return
 		for (let i = 0, len = bridges.length; i < len; i++) {
 			this.addBridge(bridges[i].channel1, bridges[i].channel2)
 		}

--- a/src/structures/BridgeManager.ts
+++ b/src/structures/BridgeManager.ts
@@ -77,7 +77,7 @@ class BridgeManager {
 	// }
 
 	async initialise() {
-		await database.connect() // there's most likely a better way to do this or place to put this
+		// await database.connect() // there's most likely a better way to do this or place to put this
 		const bridges = await database.get<BridgeSchema[]>(".channelbridges")
 		if (!bridges?.length) return
 		for (let i = 0, len = bridges.length; i < len; i++) {

--- a/src/types/ApplicationCommand.ts
+++ b/src/types/ApplicationCommand.ts
@@ -87,8 +87,10 @@ export default class ApplicationCommand {
 
 export interface ApplicationCommandAlias {
 	commandName: string
-	defaultoptions: string[] 
-	group: string
-	subcommand: string
-	description: string
+	defaultoptions?: string[] // TODO defaultoptions is an Array of OptionsResolvable
+	group?: string
+	subcommand?: string
+	description?: string
+	hidedefaults?: boolean
+	hidealloptions?: boolean
 }

--- a/src/types/ApplicationCommand.ts
+++ b/src/types/ApplicationCommand.ts
@@ -77,3 +77,11 @@ export default class ApplicationCommand {
 		this.button = options.button
 	}
 }
+
+export interface ApplicationCommandAlias {
+	commandName: string
+	defaultoptions: string[] 
+	group: string
+	subcommand: string
+	description: string
+}

--- a/src/types/ApplicationCommand.ts
+++ b/src/types/ApplicationCommand.ts
@@ -16,8 +16,13 @@ import type {
 	ContextMenuCommandInteraction,
 } from "discord.js"
 
+interface ApplicationCommandSettings {
+	ownerOnly?: boolean
+}
+
 export default class ApplicationCommand {
-	permissions?: PermissionResolvable[] | ["botowner"]
+	permissions?: PermissionResolvable[]
+	settings?: ApplicationCommandSettings
 	data:
 		| SlashCommandBuilder
 		| ContextMenuCommandBuilder
@@ -41,7 +46,8 @@ export default class ApplicationCommand {
 	button?: (interaction: ButtonInteraction) => Promise<void> | void
 
 	constructor(options: {
-		permissions?: PermissionResolvable[] | ["botowner"]
+		permissions?: PermissionResolvable[]
+		settings?: ApplicationCommandSettings
 		data:
 			| SlashCommandBuilder
 			| ContextMenuCommandBuilder
@@ -67,6 +73,7 @@ export default class ApplicationCommand {
 		button?: (interaction: ButtonInteraction) => Promise<void> | void
 	}) {
 		this.permissions = options.permissions
+		this.settings = options.settings
 		this.data = options.data
 		this.execute = options.execute
 		this.autocomplete = options.autocomplete

--- a/src/types/Database.ts
+++ b/src/types/Database.ts
@@ -1,0 +1,56 @@
+import { Role, Snowflake } from "discord.js"
+
+export interface StarboardMessageSchema {
+	starMessage: Snowflake // Message ID
+	originalMessage: Snowflake // Message ID
+}
+
+export interface LastChannelSchema {
+	guild: Snowflake // Guild ID
+	channel: Snowflake // Channel ID
+	message: Snowflake // Message ID
+}
+
+export interface InviteSchema {
+	inviterId: string
+	name: string
+	uses: number
+	expired: boolean
+	code: string
+}
+
+export interface UserSchema {
+	invitedLink: string
+	xp: number
+	aitokenusage: number
+}
+
+export interface UsernameSchema {
+	[date: string]: {
+		from: string
+		to: string
+	}
+}
+
+export interface BridgeSchema {
+	channel1: Snowflake
+	channel2: Snowflake
+}
+
+export interface RolesMenuSchema {
+	list: string
+	name: string
+}
+
+export interface RolesListSchema {
+	roles: Role[]
+}
+
+export interface GuildSettings_Schema {
+	log_channel: Snowflake // The channel id where moderation logs should go.
+	starboard_channel: Snowflake // The channel id for starred messages.
+	welcome_message: boolean // Whether to show the member welcome message.
+	leave_message: boolean // Whether to show a message when a member leaves.
+	leave_kick_message: boolean //  Whether to show a message when a member leaves, when a member is kicked or banned.
+	openai_model: string // Defaults to 'gpt-3.5-turbo'
+}

--- a/src/types/Settings.ts
+++ b/src/types/Settings.ts
@@ -6,7 +6,7 @@ interface BaseSetting {
 	name: string
 	value: string
 	description: string
-	default?: any
+	default?: string | boolean
 }
 
 interface SelectorOption {

--- a/src/utils/commands.ts
+++ b/src/utils/commands.ts
@@ -19,7 +19,7 @@ import {
 	TextInputBuilder,
 	TextInputStyle,
 } from "discord.js"
-import ApplicationCommand from "../types/ApplicationCommand"
+import ApplicationCommand, { ApplicationCommandAlias } from "../types/ApplicationCommand"
 import { client } from "../index"
 import embeds from "./embeds"
 import database from "./database"
@@ -29,9 +29,9 @@ import { Octokit } from "@octokit/rest"
 import format from "./format"
 import { stripIndents } from "common-tags"
 
-function merge(a: any, b: any, prop: any) {
+function merge<T, K extends keyof T>(a: T[], b: T[], prop: K) {
 	const reduced = a.filter(
-		(aitem: any) => !b.find((bitem: any) => aitem[prop] === bitem[prop]),
+		(aitem) => !b.find((bitem) => aitem[prop] === bitem[prop]),
 	)
 	return reduced.concat(b)
 }
@@ -58,7 +58,7 @@ async function refreshGlobalCommands() {
 		throw error
 	}
 }
-async function refreshGuildCommands(guildId: any) {
+async function refreshGuildCommands(guildId: string) {
 	const rest = new REST({ version: "10" }).setToken(token)
 	const commandList = []
 
@@ -68,7 +68,7 @@ async function refreshGuildCommands(guildId: any) {
 
 	//aliases = await process.db.json.get(`guilds`, dbpath) || {}
 
-	const aliases = (await database.get(dbpath)) || {}
+	const aliases = (await database.get<ApplicationCommandAlias>(dbpath)) || {}
 	const commands = []
 	for (const i in aliases) {
 		console.log(`i = ${i}`)

--- a/src/utils/commands.ts
+++ b/src/utils/commands.ts
@@ -36,6 +36,23 @@ function merge<T, K extends keyof T>(a: T[], b: T[], prop: K) {
 	return reduced.concat(b)
 }
 
+interface Response {
+	id: string
+	application_id: string
+	version: string
+	default_member_permissions: string[]
+	type: number
+	name: string
+	name_localizations: unknown
+	description: string
+	description_localizations: unknown
+	dm_permission: boolean
+	contexts: null
+	integration_types: number[]
+	options?: unknown[]
+	nsfw: boolean
+}
+
 async function refreshGlobalCommands() {
 	const rest = new REST({ version: "10" }).setToken(token)
 	const commandList = await getCommands() //.concat(await getContextMenuCommands())
@@ -45,9 +62,9 @@ async function refreshGlobalCommands() {
 			`Started refreshing ${commandList.length} global application (/) commands.`,
 		)
 
-		const data: any = await rest.put(Routes.applicationCommands(clientId), {
+		const data = (await rest.put(Routes.applicationCommands(clientId), {
 			body: commandList.map((e) => e.data),
-		})
+		})) as Response[]
 
 		console.log(
 			`Successfully reloaded ${data.length} global application (/) commands.`,
@@ -386,7 +403,7 @@ export default {
 			return newInteraction
 		} catch (error) {
 			console.error(error)
-			const row: any = new ActionRowBuilder().addComponents(
+			const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
 				new ButtonBuilder()
 					.setCustomId("errorreport")
 					.setLabel("Report Error")

--- a/src/utils/commands.ts
+++ b/src/utils/commands.ts
@@ -316,30 +316,28 @@ export default {
 			//console.log(command.permissions)
 			let permissionsText = "Permissions:"
 
+			if (
+				command.settings.ownerOnly &&
+				interaction.user.id !== config.permissions.botowner
+			) {
+				interaction.reply({
+					ephemeral: true,
+					embeds: embeds.warningEmbed(
+						`You don't have permission to perform the command **${commandName}**`,
+						`🚫 **Bot Owner**`,
+					),
+				})
+				return
+			}
+
 			// for every permission set in the command, check it
-			for (let i = 0; i < permlist.length; i++) {
-				if (permlist[i] == "botowner") {
-					if (interaction.user.id !== config.permissions.botowner) {
-						interaction.reply({
-							ephemeral: true,
-							embeds: embeds.warningEmbed(
-								`You don't have permission to perform the command **${commandName}**`,
-								`🚫 **Bot Owner**`,
-							),
-						})
-						return
-					}
+			for (const permission of permlist) {
+				if (interaction.memberPermissions.has(permission)) {
+					console.log("yes")
+					acceptedPermissions.push(permission)
 				} else {
-					console.log(i)
-					if (
-						(interaction.member.permissions as any).has(permlist[i])
-					) {
-						console.log("yes")
-						acceptedPermissions.push(permlist[i])
-					} else {
-						console.log("no")
-						deniedPermissions.push(permlist[i])
-					}
+					console.log("no")
+					deniedPermissions.push(permission)
 				}
 			}
 			for (let i = 0; i < deniedPermissions.length; i++) {

--- a/src/utils/commands.ts
+++ b/src/utils/commands.ts
@@ -334,7 +334,7 @@ export default {
 			let permissionsText = "Permissions:"
 
 			if (
-				command.settings.ownerOnly &&
+				command.settings?.ownerOnly &&
 				interaction.user.id !== config.permissions.botowner
 			) {
 				interaction.reply({

--- a/src/utils/database.ts
+++ b/src/utils/database.ts
@@ -100,9 +100,9 @@ export default {
 	 * Get data from the redis database
 	 *
 	 * @param {string} path The path to the data in JSON Path format (start with .)
-	 * @return {Promise<any>} Returns data from the path
+	 * @return {Promise<TData>} Returns data from the path
 	 */
-	async get(path: string): Promise<any> {
+	async get<TData>(path: string): Promise<TData> {
 		return get(path)
 	},
 	/**

--- a/src/utils/database.ts
+++ b/src/utils/database.ts
@@ -1,25 +1,15 @@
 import * as redis from "redis"
-import { client } from ".."
-
-let isReady: boolean
 
 const key = "lilybot"
-let db: any
+const db = redis.createClient({url: process.env.REDIS_URL})
 
 async function connect() {
-	if (isReady) return true
-
 	console.log(`connecting to database (url: ${process.env.REDIS_URL})`)
-	db = redis.createClient({ url: process.env.REDIS_URL })
-	db.on("error", async (err) => {
-		console.log(`Redis error: ${err}`)
-	})
-	db.on("ready", () => {
-		isReady = true
-		console.log("Redis is ready!")
-		return
-	})
 	await db.connect()
+		.then(() => {
+			console.log("Redis is ready!")
+		})
+		.catch((err) => console.error(`Redis Error: ${err}`))
 }
 
 async function check(path) {}
@@ -85,7 +75,7 @@ async function get(path: string): Promise<any> {
 
 export default {
 	async connect() {
-		connect()
+		await connect()
 	},
 	/**
 	 * Set data in the redis database

--- a/src/utils/embeds.ts
+++ b/src/utils/embeds.ts
@@ -6,6 +6,7 @@ import {
 	EmbedFooterOptions,
 	APIEmbed,
 	User,
+	Guild,
 } from "discord.js"
 import { footer } from "../config.json"
 
@@ -35,7 +36,7 @@ function embed(
 }
 
 export default {
-	errorEmbed(when: string, error: any): EmbedBuilder[] {
+	errorEmbed(when: string, error: Error): EmbedBuilder[] {
 		return embed(
 			"#d02721",
 			"An error occurred!",
@@ -52,23 +53,23 @@ export default {
 		)
 	},
 
-	successEmbed(title: string, description?: string): any {
+	successEmbed(title: string, description?: string): EmbedBuilder[] {
 		return embed("#00ff00", title, description)
 	},
 
 	messageEmbed(
 		title: string,
 		description?: string,
-		fields?: any,
+		fields?: APIEmbedField[],
 		color: ColorResolvable = "#f9beca",
-	): any {
+	): EmbedBuilder[] {
 		return embed(color, title, description, fields)
 	},
 
 	warningEmbed(
 		title: string,
 		description?: string,
-		fields?: any,
+		fields?: APIEmbedField[],
 		color: ColorResolvable = "#f2bb05",
 	) {
 		return embed(color, title, description, fields)
@@ -89,10 +90,10 @@ export default {
 	async profileEmbed(
 		title: string,
 		description?: string,
-		fields?: any,
+		fields?: APIEmbedField[],
 		user?: User,
-		guild?: any,
-	): Promise<any> {
+		guild?: Guild
+	): Promise<EmbedBuilder[]> {
 		user = await user.fetch()
 		let thumbnail: string
 

--- a/src/utils/invites.ts
+++ b/src/utils/invites.ts
@@ -1,12 +1,13 @@
 import { Guild } from "discord.js"
 import { client } from ".."
 import database from "./database"
+import { InviteSchema } from "../types/Database"
 
 async function updateInviteCache(guild: Guild) {
 	console.log(`updating invite cache for ${guild.name}`)
 
 	// Fetch all Guild Invites
-	const oldinvites = await database.get(`.guilds.${guild.id}.invites`)
+	const oldinvites = await database.get<InviteSchema>(`.guilds.${guild.id}.invites`)
 	const guildinvites = await guild.invites.fetch()
 
 	guildinvites.map(async (invite) => {

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -8,6 +8,7 @@ import {
 	MessageCreateOptions,
 	GuildEmojiRoleManager,
 	GuildTextBasedChannel,
+	Snowflake,
 } from "discord.js"
 import database from "./database"
 import { client } from ".."
@@ -18,7 +19,7 @@ export default {
 		//console.log("2")
 		//console.log(guild.id)
 
-		let channelid = await database.get(
+		let channelid = await database.get<Snowflake>(
 			`.guilds.${guild.id}.settings.log_channel`,
 		)
 		if (!channelid) {
@@ -40,7 +41,7 @@ export default {
 	},
 	async channel2(a: GuildResolvable): Promise<GuildTextBasedChannel> {
 		const guild = client.guilds.resolve(a)
-		const logchannelid = await database.get(
+		const logchannelid = await database.get<Snowflake>(
 			`.guilds.${guild.id}.settings.log_channel`,
 		)
 		const logchannel = guild.channels.resolve(logchannelid)

--- a/src/utils/openai.ts
+++ b/src/utils/openai.ts
@@ -19,7 +19,7 @@ const openai = new OpenAI({
 
 export default {
 	async openaiMessage(message: Message, random: boolean = false) {
-		const userstokens = await database.get(
+		const userstokens = await database.get<number>(
 			`.users.${message.author.id}.aitokenusage`,
 		)
 		// console.log(userstokens)
@@ -139,7 +139,7 @@ export default {
 		// console.log(chatMessages)
 
 		try {
-			const model = await settings.get(message.guild, "openai_model")
+			const model = await settings.get<string>(message.guild, "openai_model")
 			// console.log("model is " + use4o)
 
 			// let model = "gpt-3.5-turbo"

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -86,16 +86,16 @@ export default {
 			}
 		}
 	},
-	async get(guild: Guild, setting: string) {
+	async get<T>(guild: Guild, setting: string): Promise<T> {
 		if (!settingsList.map((e) => e.value).includes(setting))
 			throw new Error("invalid setting")
-		const value = await database.get(
-			`.guilds.${guild.id}.settings.${setting}`,
+		const value = await database.get<T>(
+			`.guilds.${guild.id}.settings.${setting}`
 		)
 		console.log(value)
 		return value
 	},
-	async set(guild: Guild, setting: string, value: any) {
+	async set<TValue>(guild: Guild, setting: string, value: TValue) {
 		if (!settingsList.map((e) => e.value).includes(setting))
 			throw new Error("invalid setting")
 		return await database.set(


### PR DESCRIPTION
This pull request addresses the usage of the any type within the codebase, replacing it with more specific and appropriate types.

- Resolves #62 

Changes
- Replace type `any` with specific types (1aad2f6f764a9eaa821d6822a0e17271577a35c9)
- Add Interfaces for Database Schemas (3faae9ea7c4e8d7937e5abe310b4a4f45584ef45)
- Add Interface for ApplicationCommand alias (40a38cbee717eeb1cc17f5b68765cce79a88e362)
- Add Command Settings (ee5ff893c1e2d996cb5113ceccfd9373b580208e)
- Remove `["botowner"]` in ApplicationCommand permissions (ee5ff893c1e2d996cb5113ceccfd9373b580208e)